### PR TITLE
Set up development environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-service static site built with **Nuxt 4** + **@nuxt/content** (Markdown content collections). There is no backend API, database server, or authentication to run — `@nuxt/content` uses a bundled SQLite (`better-sqlite3`) at build/dev time only.
+
+### Service: Nuxt site
+- Package manager is **npm** (`package-lock.json`). Node 22 is used.
+- `npm install` runs `nuxt prepare` via the `postinstall` hook, which generates `.nuxt` types. This is required after dependency changes.
+- Run dev server: `npm run dev` (serves at `http://localhost:3000`). Content slugs are catch-all routes like `/places/06`, `/people/38`, `/about/02`, `/instantfilm/62`, `/endnotes/80`; valid links are listed on `/tableofcontents`.
+- Static build (what Netlify runs): `npm run generate` (prerenders all routes into `dist/`; `nitro` preset is `netlify-static`). `npm run build` and `npm run preview` also work.
+- There are **no lint or test scripts** defined in `package.json`.
+
+### Notes
+- The `10yearfullres/` directory holds full-resolution source images and is not used by the running app; optimized images served by the app live under `public/photos/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for this Nuxt 4 + Nuxt Content photo site, and adds `AGENTS.md` with Cursor Cloud specific instructions for future agents.

This is a single-service static site — no backend API, database server, or auth to run.

## What was done
- Installed dependencies with `npm install` (runs `nuxt prepare` via postinstall).
- Verified the dev server (`npm run dev` on `http://localhost:3000`) serves the cover page, table of contents, and all content slug routes (`/places`, `/people`, `/about`, `/instantfilm`, `/endnotes`).
- Verified the production static build `npm run generate` prerenders all 163 routes into `dist/`.
- Performed an end-to-end browser navigation test (cover → table of contents → Places page → Next photo page).
- Added `AGENTS.md` documenting how to run/build the site and noting there are no lint/test scripts.

## Update script
`npm install` (minimal, idempotent; runs `nuxt prepare` automatically).

## Walkthrough
[photo_site_navigation_demo.mp4](https://cursor.com/agents/bc-41491a4e-f568-4ed8-83f1-379511753c5e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fphoto_site_navigation_demo.mp4)
End-to-end navigation through the running site.

[Home cover page](https://cursor.com/agents/bc-41491a4e-f568-4ed8-83f1-379511753c5e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_cover_page.webp)
[Table of contents](https://cursor.com/agents/bc-41491a4e-f568-4ed8-83f1-379511753c5e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftable_of_contents.webp)
[Places photo page](https://cursor.com/agents/bc-41491a4e-f568-4ed8-83f1-379511753c5e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplaces_photo_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41491a4e-f568-4ed8-83f1-379511753c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41491a4e-f568-4ed8-83f1-379511753c5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

